### PR TITLE
Require libs being up-to-date & don't do J2ME translation work

### DIFF
--- a/deploy
+++ b/deploy
@@ -6,6 +6,7 @@ import jenkins_utils
 import git_utils
 
 from update_translations import update_translations
+from utils import assert_packages
 
 from deploy_config import BRANCH_BASE
 
@@ -50,6 +51,8 @@ def deploy_finalize():
 
 
 def main():
+    assert_packages()
+
     if len(sys.argv) > 2:
         filename = sys.argv[0]
         arg_count = len(sys.argv) - 1

--- a/hotfix
+++ b/hotfix
@@ -5,7 +5,7 @@ import sys
 import jenkins_utils
 import git_utils
 from utils import branch_exists, checkout_ref, unstaged_changes_present, \
-    branch_exists_in_repos
+    branch_exists_in_repos, assert_packages
 from user_interaction import verify_value_with_user, \
     prompt_user_with_validation
 from deploy_config import REPOS, BRANCH_BASE
@@ -150,6 +150,8 @@ def resume_hotfix():
 
 
 def main():
+    assert_packages()
+
     if len(sys.argv) > 2:
         filename = sys.argv[0]
         arg_count = len(sys.argv) - 1

--- a/update_translations.py
+++ b/update_translations.py
@@ -46,18 +46,21 @@ def update_translations(new_version_number):
     if util.unstaged_changes_present(all_repos):
         raise Exception("One of your repositories has un-staged changes, " +
                         "please stash them and try again")
-    new_javarosa_text = get_updated_translations(j2me_repo,
-                                                 javarosa_subfolder,
-                                                 javarosa_filename)
-    new_commcare_text = get_updated_translations(j2me_repo,
-                                                 commcare_subfolder,
-                                                 commcare_filename)
+    # TODO PLM: run this on J2ME releases:
+    # new_javarosa_text = get_updated_translations(j2me_repo,
+    #                                              javarosa_subfolder,
+    #                                              javarosa_filename)
+    # new_commcare_text = get_updated_translations(j2me_repo,
+    #                                              commcare_subfolder,
+    #                                              commcare_filename)
     new_ccodk_text = get_updated_translations(commcare_android_repo,
                                               ccodk_messages_subfolder,
                                               ccodk_messages_filename)
     new_strings_text = get_updated_strings_block()
-    new_text_blocks = [new_javarosa_text, new_commcare_text,
-                       new_ccodk_text, new_strings_text]
+    new_text_blocks = [
+        new_ccodk_text, new_strings_text,
+        # new_javarosa_text, new_commcare_text,
+    ]
 
     new_branch_name = checkout_new_translations_branch(new_version_number)
     backup_old_translations_file()

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,9 @@
 import subprocess
 import os
 from deploy_config import BASE_DIR, BRANCH_BASE
+import pkg_resources
+from pkg_resources import VersionConflict
+import sys
 
 
 # None -> None
@@ -93,3 +96,18 @@ def checkout_ref(repo, ref):
     subprocess.call('git pull --tags', shell=True)
     subprocess.call('git checkout {}'.format(ref), shell=True)
     chdir_base()
+
+
+def assert_packages():
+    try:
+        pkg_resources.require(get_dependencies())
+    except VersionConflict as e:
+        print("Missing a library requirement, please update:")
+        print(str(e))
+        sys.exit(0)
+
+
+# None -> [List-of String]
+def get_dependencies():
+    with open("requirements.txt", 'r') as f:
+        return f.read().split("\n")


### PR DESCRIPTION
I think this solves http://manage.dimagi.com/default.asp?237417
Hard to tell for sure until we actually run the scripts.
- Checks that the user has the correct required python libs
- Don't perform translation updates for J2ME code. Leaving rigging that up as tech debt for later.
