### PR TITLE
Delete tag before pulling

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -93,7 +93,7 @@ def get_last_hotfix_number_in_repo(repo, version_short_str):
 def checkout_ref(repo, ref):
     print("checking out {} ref for {} repo".format(ref, repo))
     chdir_repo(repo)
-    subprocess.call('git pull --tags', shell=True)
+    subprocess.call('git fetch --tags -f', shell=True)
     subprocess.call('git checkout {}'.format(ref), shell=True)
     chdir_base()
 


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/SAAS-12347

`git pull --tags` will not work as expected if the remote tag is different than local tag. It would simply keep the local tag and discard the remote one. So later on, while doing a hotfix, we checkout from a stale tag and this causes commits to be missed in future hotfixes. 

This PR deleted the local tags first and then pulls the remote tags to avoid above issue