### PR TITLE
Fix issue preventing the next build number from updating during deployment scripts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 github3.py == 1.3.0
-python-jenkins>=0.4.13
+python-jenkins==0.4.13


### PR DESCRIPTION
Since the update of the Jenkins machine to version `2.492.2` the deploy scripts are failing to set the release jobs' Next Build Number with a 500:
```
Traceback (most recent call last):
  File "/Users/ahmadvazirna/.pyenv/versions/hq/lib/python3.9/site-packages/jenkins/__init__.py", line 578, in jenkins_request
    return self._response_handler(
  File "/Users/ahmadvazirna/.pyenv/versions/hq/lib/python3.9/site-packages/jenkins/__init__.py", line 539, in _response_handler
    response.raise_for_status()
  File "/Users/ahmadvazirna/.pyenv/versions/hq/lib/python3.9/site-packages/requests/models.py", line 1024, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 500 Server Error: Server Error for url: https://jenkins.dimagi.com/job/Area%20Mapper/nextbuildnumber/submit
```
During the investigation, it was noticed that there is a difference in terms of the payload format between version `0.4.13` and the latest, 1.8.2. The 0.3.14 version uses `form-data` and 1.8.2 as `raw data`, which seems to be rejected by the version of Jenkins API in use. So this PR sets the version of this library to be specifically `0.4.13`.

